### PR TITLE
Fix incorrect deduplication by adding primary key to distinct

### DIFF
--- a/lib/join.ex
+++ b/lib/join.ex
@@ -658,11 +658,11 @@ defmodule AshSql.Join do
       sort = joined_query.__ash_bindings__.sort
 
       distinct =
-        if sort != [] && Keyword.keyword?(sort) do
-          Enum.map(sort, fn {attribute, direction} -> {direction, attribute} end)
-        else
+        Enum.flat_map(sort, fn
+          {attribute, direction} when is_atom(attribute) -> [{direction, attribute}]
+          {%Ash.Query.Calculation{}, _} -> []
+        end) ++
           Ash.Resource.Info.primary_key(joined_query.__ash_bindings__.resource)
-        end
 
       if joined_query.__ash_bindings__.sql_behaviour.multicolumn_distinct?() do
         from(row in joined_query,


### PR DESCRIPTION
This PR fixes an issue where records with identical sort fields but different primary keys were incorrectly deduplicated by distinct.

- The primary key is now always appended to the distinct clause to ensure uniqueness even when sort fields alone are not sufficient.

- Calculations are currently excluded from distinct, since it's unclear how to include them properly at the SQL level.
  - While some calculations (e.g. expr/1-based) could theoretically be expressed in Ecto, that is not yet implemented.

  - Nonetheless, this fix significantly improves correctness and covers most practical cases.